### PR TITLE
support when expression for command palette

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,6 +208,10 @@
 															"type": "number",
 															"description": "Delay BEFORE executing this command."
 														},
+														"when": {
+															"type": "string",
+															"markdownDescription": "a `when` expression of when the command will be avaliable at the command palette. See [VSCode API](https://code.visualstudio.com/api/references/when-clause-contexts)."
+														},
 														"icon": {
 															"type": "string",
 															"markdownDescription": "Add icon from codicons list [Icons list](https://code.visualstudio.com/api/references/icons-in-labels#icon-listing)"

--- a/package.json
+++ b/package.json
@@ -77,6 +77,10 @@
 											"description": "Command id to execute."
 										},
 										"args": {},
+										"when": {
+											"type": "string",
+											"markdownDescription": "a `when` expression of when the command will be avaliable at the command palette. See [VSCode API](https://code.visualstudio.com/api/references/when-clause-contexts)."
+										},
 										"delay": {
 											"type": "number",
 											"description": "Delay BEFORE executing this command."

--- a/src/types.ts
+++ b/src/types.ts
@@ -62,6 +62,7 @@ export interface CommandObject {
 	statusBar?: StatusBar;
 	sequence?: Sequence;
 	hidden?: boolean;
+	when?: string;
 }
 /**
  * Add command/folder to status bar


### PR DESCRIPTION
Allow specifying a `when` expression for commands.

Currently, due to VSCode limitations, it's supported only in the Command Palette (so it has any effect only if `populateCommandPalette` is checked).

Hopefully, with either VSCode expose an API to evaluate a when expression, or will support it in tree view & status bar, we can extend it's support in the extension as well. But it won't happen any time soon, it seems.