### PR TITLE
Add full keybinding args completions for `commands.run`

### DIFF
--- a/data/keybindings.schema.json
+++ b/data/keybindings.schema.json
@@ -1,0 +1,45 @@
+{
+	"$schema": "http://json-schema.org/draft-07/schema",
+	"type": "array",
+	"items": {
+		"if": {
+			"properties": {
+				"command": {
+					"const": "commands.run"
+				}
+			}
+		},
+		"then": {
+			"required": [
+				"args"
+			],
+			"properties": {
+				"args": {
+					"type": "array",
+					"items": {
+						"anyOf": [
+							{
+								"type": "string"
+							},
+							{
+								"type": "object",
+								"required": [
+									"command"
+								],
+								"properties": {
+									"command": {
+										"type": "string"
+									},
+									"args": {},
+									"delay": {
+										"type": "number"
+									}
+								}
+							}
+						]
+					}
+				}
+			}
+		}
+	}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "1.6.0",
 			"license": "MIT",
 			"dependencies": {
+				"jsonc-parser": "^3.2.0",
 				"jsonc-simple-parser": "^2.2.1",
 				"lodash": "^4.17.21",
 				"open": "^8.4.0"
@@ -1892,6 +1893,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"node_modules/jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"node_modules/jsonc-simple-parser": {
 			"version": "2.2.1",
@@ -4540,6 +4546,11 @@
 			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true
+		},
+		"jsonc-parser": {
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.2.0.tgz",
+			"integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w=="
 		},
 		"jsonc-simple-parser": {
 			"version": "2.2.1",

--- a/package.json
+++ b/package.json
@@ -1018,6 +1018,11 @@
 				"command": "commands.escapeCommandUriArgument",
 				"title": "Escape command uri argument",
 				"category": "Commands"
+			},
+			{
+				"command": "commands.run",
+				"title": "Run custom command",
+				"category": "Commands"
 			}
 		],
 		"menus": {
@@ -1093,9 +1098,19 @@
 				{
 					"command": "commands.deleteCommand",
 					"when": "false"
+				},
+				{
+					"command": "commands.run",
+					"when": "false"
 				}
 			]
-		}
+		},
+		"jsonValidation": [
+			{
+				"fileMatch": "**/keybindings.json",
+				"url": "./data/keybindings.schema.json"
+			}
+		]
 	},
 	"scripts": {
 		"vscode:prepublish": "webpack --mode production --color",
@@ -1118,6 +1133,7 @@
 		"webpack-cli": "^4.10.0"
 	},
 	"dependencies": {
+		"jsonc-parser": "^3.2.0",
 		"jsonc-simple-parser": "^2.2.1",
 		"lodash": "^4.17.21",
 		"open": "^8.4.0"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import { updateCommandPalette } from './commandPalette';
 import { registerExtensionCommands } from './commands';
 import { updateDocumentLinkProvider } from './documentLinksProvider';
 import { getKeybindings, VSCodeKeybindingItem } from './getKeybindings';
+import keybindingsCompletions from './keybindingsCompletions';
 import { VSCodeCommandWithoutCategory } from './quickPick';
 import { updateUserCommands } from './registerUserCommands';
 import { updateStatusBarItems, updateStatusBarItemsVisibilityBasedOnActiveEditor } from './statusBar';
@@ -45,6 +46,7 @@ export async function activate(context: ExtensionContext) {
 
 
 	registerExtensionCommands();
+	keybindingsCompletions();
 
 	await setWorkspaceIdToContext(context);
 	updateEverything(context);

--- a/src/keybindingsCompletions.ts
+++ b/src/keybindingsCompletions.ts
@@ -1,0 +1,65 @@
+import { commands, CompletionItemKind, languages, Range } from 'vscode';
+import { findNodeAtOffset, getNodePath, getNodeValue, Node, parseTree } from 'jsonc-parser';
+import { getAllCommandPaletteCommands } from './quickPick';
+
+export default () => {
+	languages.registerCompletionItemProvider({
+		pattern: '**/{keybindings.json,package.json}',
+	}, {
+		async provideCompletionItems(document, position) {
+			const root = parseTree(document.getText(), []);
+			if (!root) {
+				return;
+			}
+			const node = findNodeAtOffset(root, document.offsetAt(position));
+			if (node?.type !== 'string') {
+				return;
+			}
+
+			let path = getNodePath(node);
+			const patchMatches = (compare: string[], useStartsWith = false) => {
+				if (!useStartsWith && compare.length !== path.length) {
+					return undefined;
+				}
+				return compare.every((item, i) => item === '*' || item === path[i]);
+			};
+
+			if (languages.match({ pattern: '**/package.json' }, document)) {
+				if (!patchMatches(['contributes', 'keybindings'], true)) {
+					return;
+				}
+				path = path.slice(2);
+			}
+			let keybindingNode: Node | undefined;
+			if (patchMatches(['*', 'args', '*'])) {
+				keybindingNode = node.parent!.parent!.parent!;
+			} else if (patchMatches(['*', 'args', '*', 'command'])) {
+				keybindingNode = node.parent!.parent!.parent!.parent!.parent!;
+			}
+			if (!keybindingNode) {
+				return;
+			}
+
+			const keybinding = getNodeValue(keybindingNode);
+			if (keybinding.command !== 'commands.run') {
+				return;
+			}
+
+			const commandTitles = Object.fromEntries((await getAllCommandPaletteCommands().catch(() => [])).map(({ command, title }) => [command, title]));
+			const commandsList = await commands.getCommands(true);
+
+			const start = document.positionAt(node.offset + 1);
+			const end = document.positionAt(node.offset + 1 + node.length - 2);
+			const range = new Range(start, end);
+			// eslint-disable-next-line consistent-return
+			return commandsList.map((command, i) => ({
+				label: command,
+				kind: CompletionItemKind.Constant,
+				detail: commandTitles[command],
+				range,
+				// ensure builtin commands showed earlier
+				sortText: i.toString().padStart(5, '0'),
+			}));
+		},
+	});
+};

--- a/src/quickPick.ts
+++ b/src/quickPick.ts
@@ -136,7 +136,12 @@ interface VSCodeCommand {
 
 export type VSCodeCommandWithoutCategory = Omit<VSCodeCommand, 'category'>;
 
-async function getAllCommandPaletteCommands(): Promise<VSCodeCommandWithoutCategory[]> {
+let allCommandPaletteCommandsCached: VSCodeCommandWithoutCategory[] | undefined;
+
+export async function getAllCommandPaletteCommands(): Promise<VSCodeCommandWithoutCategory[]> {
+	if (allCommandPaletteCommandsCached) {
+		return allCommandPaletteCommandsCached;
+	}
 	if ($state.allCommandPaletteCommands.length) {
 		return $state.allCommandPaletteCommands;
 	}
@@ -147,6 +152,7 @@ async function getAllCommandPaletteCommands(): Promise<VSCodeCommandWithoutCateg
 		...commandsFromExtensions,
 	];
 	$state.allCommandPaletteCommands = allCommandPaletteCommands;
+	allCommandPaletteCommandsCached = allCommandPaletteCommands;
 	return allCommandPaletteCommands;
 }
 

--- a/src/quickPick.ts
+++ b/src/quickPick.ts
@@ -136,12 +136,7 @@ interface VSCodeCommand {
 
 export type VSCodeCommandWithoutCategory = Omit<VSCodeCommand, 'category'>;
 
-let allCommandPaletteCommandsCached: VSCodeCommandWithoutCategory[] | undefined;
-
 export async function getAllCommandPaletteCommands(): Promise<VSCodeCommandWithoutCategory[]> {
-	if (allCommandPaletteCommandsCached) {
-		return allCommandPaletteCommandsCached;
-	}
 	if ($state.allCommandPaletteCommands.length) {
 		return $state.allCommandPaletteCommands;
 	}
@@ -152,7 +147,6 @@ export async function getAllCommandPaletteCommands(): Promise<VSCodeCommandWitho
 		...commandsFromExtensions,
 	];
 	$state.allCommandPaletteCommands = allCommandPaletteCommands;
-	allCommandPaletteCommandsCached = allCommandPaletteCommands;
 	return allCommandPaletteCommands;
 }
 


### PR DESCRIPTION
@usernamehw This is what I mean in https://github.com/usernamehw/vscode-commands/issues/18#issuecomment-1411973557, I have some keybindings in keymap extension and keybindings.json like:

```json
{
  "key": "cmd+\\",
  "command": "commands.run",
  "args": [
    "volar.action.restartServer",
    {
      "command": "workbench.action.quickOpen",
      "args": "view vue sem",
      "delay": 500
    }
  ],
  "when": "editorLangId == 'vue'"
}
```

It adds autocomplete for all this!