### PR TITLE
[codicon suggest] Align all icon positioning

### DIFF
--- a/src/commands/suggestCodiconsCommand.ts
+++ b/src/commands/suggestCodiconsCommand.ts
@@ -2,10 +2,15 @@ import { QuickPickItem, TextEditor, window } from 'vscode';
 import { codiconNames } from '../codiconNames';
 
 export async function suggestCodiconsCommand(editor: TextEditor) {
-	const quickPickItems = codiconNames.map(codiconName => ({
-		label: codiconName,
-		description: `$(${codiconName})`,
-	} as QuickPickItem));
+	type CustomQuickPickItem = QuickPickItem & {value: string};
+
+	const quickPickItems = codiconNames.map(
+		codiconName =>
+			({
+				label: `$(${codiconName}) ${codiconName}`,
+				value: codiconName
+			} as CustomQuickPickItem),
+	);
 
 	const picked = await window.showQuickPick(quickPickItems);
 	if (!picked) {
@@ -13,6 +18,6 @@ export async function suggestCodiconsCommand(editor: TextEditor) {
 	}
 
 	editor.edit(builder => {
-		builder.insert(editor.selection.active, picked.label);
+		builder.insert(editor.selection.active, picked.value);
 	});
 }


### PR DESCRIPTION
Hi! I also had a similar extension to command to copy codicon into clipboard, but I was always too lazy to set up auto-updating codicons on CI, so would be happy to use your command instead. But for now icons are positioned at the end of quick pick and thus its harder to search through them, I don't see anything bad in positioning them at the start instead. I believe this is what most users expect: for example all "native quickpicks" such as `workbench.action.quickOpen` also position file icon at the start, so IMO icon should be always positioned at the start without any exceptions (I believe it was even in vscode guidelines).