### PR TITLE
Support label-value in pickString options

### DIFF
--- a/data/settings.schema.json
+++ b/data/settings.schema.json
@@ -1,6 +1,5 @@
 {
 	"$schema": "http://json-schema.org/draft-07/schema",
-
 	"definitions": {
 		"commandItem": {
 			"oneOf": [
@@ -12,6 +11,19 @@
 					"$ref": "#/definitions/commandObject"
 				}
 			]
+		},
+		"pickStringOptionObject": {
+			"type": "object",
+			"properties": {
+				"label": {
+					"type": "string",
+					"minLength": 1
+				},
+				"value": {
+					"type": "string",
+					"minLength": 1
+				}
+			}
 		},
 		"statusBar": {
 			"type": "object",
@@ -217,7 +229,14 @@
 									"options": {
 										"type": "array",
 										"items": {
-											"type": "string"
+											"oneOf": [
+												{
+													"type": "string"
+												},
+												{
+													"$ref": "#/definitions/pickStringOptionObject"
+												}
+											]
 										},
 										"minItems": 1
 									},

--- a/src/substituteVariables.ts
+++ b/src/substituteVariables.ts
@@ -1,7 +1,7 @@
 import { homedir } from 'os';
 import path from 'path';
 import { commands, env, window, workspace } from 'vscode';
-import { type Inputs } from './types';
+import { type Inputs, type InputPickStringOption } from './types';
 import { extUtils } from './utils/extUtils';
 import { utils } from './utils/utils';
 import { vscodeUtils } from './utils/vscodeUtils';
@@ -325,9 +325,12 @@ async function replaceInputVariable(inputName: string, inputs: Inputs | undefine
 	}
 
 	if (foundInput.type === 'pickString') {
-		const quickPickResult = defaultStringValue(await window.showQuickPick(foundInput.options, {
+		const quickPickRawResult = await window.showQuickPick(foundInput.options, {
 			title: foundInput.description,
-		}), foundInput.default);
+		}) as InputPickStringOption;
+		// pickString supports either strings or objects in the form of { label: string, value: string }
+		const quickPickResultValue = typeof quickPickRawResult === 'string' ? quickPickRawResult : quickPickRawResult?.value;
+		const quickPickResult = defaultStringValue(quickPickResultValue, foundInput.default);
 		return quickPickResult;
 	} else if (foundInput.type === 'promptString') {
 		const inputResult = defaultStringValue(await window.showInputBox({

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { QuickPickItem } from "vscode";
 
 export interface ExtensionConfig {
 	/**
@@ -81,6 +82,13 @@ interface InputPromptString {
 	password?: boolean;
 	convertType?: 'boolean' | 'number';
 }
+
+interface InputQuickPickitem extends QuickPickItem {
+	value: string;
+}
+
+export type InputPickStringOption = InputQuickPickitem | string | undefined;
+
 interface InputPickString {
 	id: string;
 	type: 'pickString';


### PR DESCRIPTION
When using `pickString` as input type, VSCode allows both simple strings and objects with the shape `{ label: string, value: string }`.

This PR adds support for the latter, by checking if the option picked by the user returns a string or an object, and extracting the object value if necessary.

- updated `replaceInputVariable` logic when handling `pickString` to check if the item returned by VSCode is a string or an object, and handle the object by extracting its `value`
- updated `settings-schema.json` with definition of label-value type when defining `pickString` options